### PR TITLE
Support MapReduce executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Stores files on a SFTP Server
 - **port**: (string, default: `22`)
 - **user**: (string, required)
 - **password**: (string, default: `null`)
-- **secret_key_file**: (string, default: `null`)
+- **secret_key_file**: (string, default: `null`) [see below](#secret-keyfile-configuration)
 - **secret_key_passphrase**: (string, default: `""`)
 - **user_directory_is_root**: (boolean, default: `true`)
 - **timeout**: sftp connection timeout seconds (integer, default: `600`)
@@ -40,6 +40,32 @@ out:
   path_prefix: /data/sftp
   file_ext: _20151020.tsv
   sequence_format: ".%01d%01d"
+```
+
+### Secret Keyfile configuration
+
+Please set path of secret_key_file as follows.
+```
+out:
+  type: sftp
+  ...
+  secret_key_file: /path/to/id_rsa
+  ...
+```
+
+You can also embed contents of secret_key_file at config.yml.
+```
+out:
+  type: sftp
+  ...
+  secret_key_file:
+    content |
+      -----BEGIN RSA PRIVATE KEY-----
+      ABCDEFG...
+      HIJKLMN...
+      OPQRSTU...
+      -----END RSA PRIVATE KEY-----
+  ...
 ```
 
 ## Run Example

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -11,6 +11,7 @@ import org.embulk.config.TaskSource;
 import org.embulk.spi.Exec;
 import org.embulk.spi.FileOutputPlugin;
 import org.embulk.spi.TransactionalFileOutput;
+import org.embulk.spi.unit.LocalFile;
 import org.slf4j.Logger;
 
 import java.util.List;
@@ -39,7 +40,8 @@ public class SftpFileOutputPlugin
 
         @Config("secret_key_file")
         @ConfigDefault("null")
-        public Optional<String> getSecretKeyFilePath();
+        public Optional<LocalFile> getSecretKeyFilePath();
+        public void setSecretKeyFilePath(Optional<LocalFile> secretKeyFilePath);
 
         @Config("secret_key_passphrase")
         @ConfigDefault("\"\"")


### PR DESCRIPTION
Embulk supports distributed executor such as an [embulk-executor-mapreduce](https://github.com/embulk/embulk-executor-mapreduce).

This executor run tasks on remote server and couldn't read local file path that is written at  config.yml.
Because file is not there.

I changed `secret_key_file` parameter to accept embedded secret key.

```yaml
out:
  type: sftp
  ...
  secret_key_file:
    content |
      -----BEGIN RSA PRIVATE KEY-----
      ABCDEFG...
      HIJKLMN...
      OPQRSTU...
      -----END RSA PRIVATE KEY-----
  ...
```

This changes keeps a backward compatibility.
So we can set local file path as before.
```yaml
out:
  type: sftp
  ...
  secret_key_file: /path/to/id_rsa
  ...
```