### PR TITLE
Fix error handling

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -137,7 +137,9 @@ public class SftpFileOutput
             logger.error(e.getMessage());
             Throwables.propagate(e);
         }
-        buffer.release();
+        finally {
+            buffer.release();
+        }
     }
 
     @Override

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -7,6 +7,7 @@ import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.commons.vfs2.provider.sftp.IdentityInfo;
 import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+import org.embulk.config.ConfigException;
 import org.embulk.config.TaskReport;
 import org.embulk.spi.Buffer;
 import org.embulk.spi.Exec;
@@ -56,7 +57,7 @@ public class SftpFileOutput
         }
         catch (FileSystemException e) {
             logger.error(e.getMessage());
-            throw new RuntimeException(e);
+            throw new ConfigException(e);
         }
 
         return manager;
@@ -87,7 +88,7 @@ public class SftpFileOutput
         }
         catch (FileSystemException e) {
             logger.error(e.getMessage());
-            throw new RuntimeException(e);
+            throw new ConfigException(e);
         }
 
         return fsOptions;
@@ -196,7 +197,7 @@ public class SftpFileOutput
         }
         catch (URISyntaxException e) {
             logger.error(e.getMessage());
-            throw new RuntimeException(e);
+            throw new ConfigException(e);
         }
     }
 

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -164,7 +164,7 @@ public class SftpFileOutput
     @Override
     public TaskReport commit()
     {
-        return null;
+        return Exec.newTaskReport();
     }
 
 


### PR DESCRIPTION
I fixed error handlings and so on.

* throw ConfigException instead of RuntimeException
* Release resource at finally block
* Return `Exec.newTaskReport()` when close() method is called