### PR TITLE
Support proxy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Stores files on a SFTP Server
 ## Configuration
 
 - **host**: (string, required)
-- **port**: (string, default: `22`)
+- **port**: (int, default: `22`)
 - **user**: (string, required)
 - **password**: (string, default: `null`)
 - **secret_key_file**: (string, default: `null`) [see below](#secret-keyfile-configuration)
@@ -25,6 +25,19 @@ Stores files on a SFTP Server
 - **file_ext**: Extension of output files (string, required)
 - **sequence_format**: Format for sequence part of output files (string, default: `".%03d.%02d"`)
 
+### Proxy configuration
+
+- **proxy**:
+    - **type**: (string(http | socks | stream), required, default: `null`)
+        - **http**: use HTTP Proxy
+        - **socks**: use SOCKS Proxy
+        - **stream**: Connects to the SFTP server through a remote host reached by SSH
+    - **host**: (string, required)
+    - **port**: (int, default: `22`)
+    - **user**: (string, optional)
+    - **password**: (string, optional, default: `null`)
+    - **command**: (string, optional)
+    
 ## Example
 
 ```yaml
@@ -42,10 +55,31 @@ out:
   sequence_format: ".%01d%01d"
 ```
 
+With proxy
+```yaml
+out:
+  type: sftp
+  host: 127.0.0.1
+  port: 22
+  user: embulk
+  secret_key_file: /Users/embulk/.ssh/id_rsa
+  secret_key_passphrase: secret_pass
+  user_directory_is_root: false
+  timeout: 600
+  path_prefix: /data/sftp
+  proxy:
+    type: http
+    host: proxy_host
+    port: 8080
+    user: proxy_user
+    password: proxy_secret_pass
+    command:
+```
+
 ### Secret Keyfile configuration
 
 Please set path of secret_key_file as follows.
-```
+```yaml
 out:
   type: sftp
   ...
@@ -54,7 +88,7 @@ out:
 ```
 
 You can also embed contents of secret_key_file at config.yml.
-```
+```yaml
 out:
   type: sftp
   ...

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     testCompile "org.embulk:embulk-core:0.8.6:tests"
     testCompile "org.embulk:embulk-standards:0.8.6"
     testCompile "org.apache.sshd:apache-sshd:1.1.0+"
+    testCompile "org.littleshoot:littleproxy:1.1.0-beta1"
+    testCompile "io.netty:netty-all:4.0.34.Final"
 }
 
 jacocoTestReport {

--- a/src/main/java/org/embulk/output/sftp/ProxyTask.java
+++ b/src/main/java/org/embulk/output/sftp/ProxyTask.java
@@ -1,0 +1,85 @@
+package org.embulk.output.sftp;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Optional;
+import org.apache.commons.vfs2.FileSystemOptions;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
+import org.embulk.config.Config;
+import org.embulk.config.ConfigDefault;
+import org.embulk.config.ConfigException;
+import org.embulk.config.Task;
+
+import java.util.Locale;
+
+interface ProxyTask
+        extends Task
+{
+    @Config("type")
+    public ProxyType getType();
+
+    @Config("host")
+    public Optional<String> getHost();
+
+    @Config("user")
+    @ConfigDefault("null")
+    public Optional<String> getUser();
+
+    @Config("password")
+    @ConfigDefault("null")
+    public Optional<String> getPassword();
+
+    @Config("port")
+    @ConfigDefault("22")
+    public int getPort();
+
+    @Config("command")
+    @ConfigDefault("null")
+    public Optional<String> getCommand();
+
+    public enum ProxyType
+    {
+        HTTP,
+        SOCKS,
+        STREAM;
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return name().toLowerCase(Locale.ENGLISH);
+        }
+
+        @JsonCreator
+        public static ProxyType fromString(String value)
+        {
+            switch (value) {
+                case "http":
+                    return HTTP;
+                case "socks":
+                    return SOCKS;
+                case "stream":
+                    return STREAM;
+                default:
+                    throw new ConfigException(String.format("Unknown proxy type '%s'. Supported proxy types are http, socks, stream", value));
+            }
+        }
+
+        public static SftpFileSystemConfigBuilder setProxyType(SftpFileSystemConfigBuilder builder, FileSystemOptions fsOptions, ProxyTask.ProxyType type)
+        {
+            SftpFileSystemConfigBuilder.ProxyType setType = null;
+            switch (type) {
+                case HTTP:
+                    setType = SftpFileSystemConfigBuilder.PROXY_HTTP;
+                    break;
+                case SOCKS:
+                    setType = SftpFileSystemConfigBuilder.PROXY_SOCKS5;
+                    break;
+                case STREAM:
+                    setType = SftpFileSystemConfigBuilder.PROXY_STREAM;
+            }
+            builder.setProxyType(fsOptions, setType);
+            return builder;
+        }
+    }
+}

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutputPlugin.java
@@ -68,6 +68,10 @@ public class SftpFileOutputPlugin
         @Config("sequence_format")
         @ConfigDefault("\"%03d.%02d.\"")
         public String getSequenceFormat();
+
+        @Config("proxy")
+        @ConfigDefault("null")
+        public Optional<ProxyTask> getProxy();
     }
 
     @Override

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -16,6 +16,7 @@ import org.apache.sshd.server.scp.ScpCommandFactory;
 import org.apache.sshd.server.session.ServerSession;
 import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
 import org.embulk.EmbulkTestRuntime;
+import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigLoader;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.TaskReport;
@@ -36,6 +37,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.slf4j.Logger;
 
 import java.io.File;
@@ -74,6 +77,8 @@ public class TestSftpFileOutputPlugin
     private SshServer sshServer;
     private static final String HOST = "127.0.0.1";
     private static final int PORT = 20022;
+    private static final String PROXY_HOST = "127.0.0.1";
+    private static final int PROXY_PORT = 8080;
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
     private static final String SECRET_KEY_FILE = Resources.getResource("id_rsa").getPath();
@@ -94,13 +99,18 @@ public class TestSftpFileOutputPlugin
         SftpFileOutputPlugin sftpFileOutputPlugin = new SftpFileOutputPlugin();
         runner = new FileOutputRunner(sftpFileOutputPlugin);
 
+        sshServer = createSshServer(HOST, PORT, USERNAME, PASSWORD);
+    }
+
+    private SshServer createSshServer(String host, int port, final String sshUsername, final String sshPassword)
+    {
         // setup a mock sftp server
-        sshServer = SshServer.setUpDefaultServer();
+        SshServer sshServer = SshServer.setUpDefaultServer();
         VirtualFileSystemFactory fsFactory = new VirtualFileSystemFactory();
-        fsFactory.setUserHomeDir(USERNAME, testFolder.getRoot().toPath());
+        fsFactory.setUserHomeDir(sshUsername, testFolder.getRoot().toPath());
         sshServer.setFileSystemFactory(fsFactory);
-        sshServer.setHost(HOST);
-        sshServer.setPort(PORT);
+        sshServer.setHost(host);
+        sshServer.setPort(port);
         sshServer.setSubsystemFactories(Collections.<NamedFactory<Command>>singletonList(new SftpSubsystemFactory()));
         sshServer.setCommandFactory(new ScpCommandFactory());
         sshServer.setKeyPairProvider(new SimpleGeneratorHostKeyProvider());
@@ -109,7 +119,7 @@ public class TestSftpFileOutputPlugin
             @Override
             public boolean authenticate(final String username, final String password, final ServerSession session)
             {
-                return USERNAME.contentEquals(username) && PASSWORD.contentEquals(password);
+                return sshUsername.contentEquals(username) && sshPassword.contentEquals(password);
             }
         });
         sshServer.setPublickeyAuthenticator(new PublickeyAuthenticator()
@@ -127,6 +137,14 @@ public class TestSftpFileOutputPlugin
         catch (IOException e) {
             logger.debug(e.getMessage(), e);
         }
+        return sshServer;
+    }
+
+    private HttpProxyServer createProxyServer(int port)
+    {
+        return DefaultHttpProxyServer.bootstrap()
+                .withPort(port)
+                .start();
     }
 
     @After
@@ -269,6 +287,49 @@ public class TestSftpFileOutputPlugin
         assertEquals(pathPrefix, task.getPathPrefix());
         assertEquals("txt", task.getFileNameExtension());
         assertEquals("%03d.%02d.", task.getSequenceFormat());
+        assertEquals(Optional.absent(), task.getProxy());
+    }
+
+    @Test
+    public void testConfigValuesIncludingProxy()
+    {
+        // setting embulk config
+        final String pathPrefix = "/test/testUserPassword";
+        String configYaml = "" +
+                "type: sftp\n" +
+                "host: " + HOST + "\n" +
+                "user: " + USERNAME + "\n" +
+                "path_prefix: " + pathPrefix + "\n" +
+                "file_ext: txt\n" +
+                "proxy: \n" +
+                "  type: http\n" +
+                "  host: proxy_host\n" +
+                "  port: 80 \n" +
+                "  user: proxy_user\n" +
+                "  password: proxy_pass\n" +
+                "  command: proxy_command\n" +
+                "formatter:\n" +
+                "  type: csv\n" +
+                "  newline: CRLF\n" +
+                "  newline_in_field: LF\n" +
+                "  header_line: true\n" +
+                "  charset: UTF-8\n" +
+                "  quote_policy: NONE\n" +
+                "  quote: \"\\\"\"\n" +
+                "  escape: \"\\\\\"\n" +
+                "  null_string: \"\"\n" +
+                "  default_timezone: 'UTC'";
+
+        ConfigSource config = getConfigFromYaml(configYaml);
+        PluginTask task = config.loadConfig(PluginTask.class);
+
+        ProxyTask proxy = task.getProxy().get();
+        assertEquals("proxy_command", proxy.getCommand().get());
+        assertEquals("proxy_host", proxy.getHost().get());
+        assertEquals("proxy_user", proxy.getUser().get());
+        assertEquals("proxy_pass", proxy.getPassword().get());
+        assertEquals(80, proxy.getPort());
+        assertEquals(ProxyTask.ProxyType.HTTP, proxy.getType());
     }
 
     // Cases
@@ -354,6 +415,60 @@ public class TestSftpFileOutputPlugin
     }
 
     @Test
+    public void testUserSecretKeyFileWithProxy()
+    {
+        HttpProxyServer proxyServer = null;
+        try {
+             proxyServer = createProxyServer(PROXY_PORT);
+
+            // setting embulk config
+            final String pathPrefix = "/test/testUserPassword";
+            String configYaml = "" +
+                    "type: sftp\n" +
+                    "host: " + HOST + "\n" +
+                    "port: " + PORT + "\n" +
+                    "user: " + USERNAME + "\n" +
+                    "secret_key_file: " + SECRET_KEY_FILE + "\n" +
+                    "secret_key_passphrase: " + SECRET_KEY_PASSPHRASE + "\n" +
+                    "path_prefix: " + testFolder.getRoot().getAbsolutePath() + pathPrefix + "\n" +
+                    "file_ext: txt\n" +
+                    "proxy: \n" +
+                    "  type: http\n" +
+                    "  host: " + PROXY_HOST + "\n" +
+                    "  port: " + PROXY_PORT + " \n" +
+                    "  user: " + USERNAME + "\n" +
+                    "  password: " + PASSWORD + "\n" +
+                    "  command: \n" +
+                    "formatter:\n" +
+                    "  type: csv\n" +
+                    "  newline: CRLF\n" +
+                    "  newline_in_field: LF\n" +
+                    "  header_line: true\n" +
+                    "  charset: UTF-8\n" +
+                    "  quote_policy: NONE\n" +
+                    "  quote: \"\\\"\"\n" +
+                    "  escape: \"\\\\\"\n" +
+                    "  null_string: \"\"\n" +
+                    "  default_timezone: 'UTC'";
+
+            // runner.transaction -> ...
+            run(configYaml, Optional.<Integer>absent());
+
+            List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
+            assertThat(fileList, hasItem(containsString(pathPrefix + "001.00.txt")));
+
+            assertRecordsInFile(String.format("%s/%s001.00.txt",
+                    testFolder.getRoot().getAbsolutePath(),
+                    pathPrefix));
+        }
+        finally {
+            if (proxyServer != null) {
+                proxyServer.stop();
+            }
+        }
+    }
+
+    @Test
     public void testTimeout()
     {
         // setting embulk config
@@ -387,5 +502,31 @@ public class TestSftpFileOutputPlugin
 
         // runner.transaction -> ...
         run(configYaml, Optional.of(60)); // sleep 1 minute while processing
+    }
+
+    @Test
+    public void testProxyType()
+    {
+        // test valueOf()
+        assertEquals("http", ProxyTask.ProxyType.valueOf("HTTP").toString());
+        assertEquals("socks", ProxyTask.ProxyType.valueOf("SOCKS").toString());
+        assertEquals("stream", ProxyTask.ProxyType.valueOf("STREAM").toString());
+        try {
+            ProxyTask.ProxyType.valueOf("non-existing-type");
+        }
+        catch (Exception e) {
+            assertEquals(IllegalArgumentException.class, e.getClass());
+        }
+
+        // test fromString
+        assertEquals(ProxyTask.ProxyType.HTTP, ProxyTask.ProxyType.fromString("http"));
+        assertEquals(ProxyTask.ProxyType.SOCKS, ProxyTask.ProxyType.fromString("socks"));
+        assertEquals(ProxyTask.ProxyType.STREAM, ProxyTask.ProxyType.fromString("stream"));
+        try {
+            ProxyTask.ProxyType.fromString("non-existing-type");
+        }
+        catch (Exception e) {
+            assertEquals(ConfigException.class, e.getClass());
+        }
     }
 }


### PR DESCRIPTION
I added proxy settings based on #6 and unit tests.

`type` parameter can be taken 3 values.

- **http** use HTTP Proxy
- **socks** use SOCKS Proxy
- **stream** Connects to the SFTP server through a remote host reached by SSH

We can set `command` parameter when something UNIX commands are required to connect.

### Configuration

`proxy:` block is optional.

```yaml
out:
  type: sftp
  host: 127.0.0.1
  port: 22
  user: embulk
  secret_key_file: /Users/embulk/.ssh/id_rsa
  secret_key_passphrase: secret_pass
  user_directory_is_root: false
  timeout: 600
  path_prefix: /data/sftp
  proxy:
    type: http
    host: proxy_host
    port: 8080
    user: proxy_user
    password: proxy_secret_pass
    command:
```

### Unit tests

Unit test works as following.
* create virtual SSH server(127.0.0.1:20022)
* create virtual HTTP proxy server(127.0.0.1:8080)
* connect to SSH server through HTTP proxy server.
* confirm data upload was succeeded.