### PR TITLE
Retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 .idea
 *.iml
 example/config.yml
+.vagrant

--- a/README.md
+++ b/README.md
@@ -103,10 +103,21 @@ out:
 ```
 
 ## Run Example
-replace settings in `example/sample.yml` before running.
 
 ```
 $ ./gradlew classpath
+```
+
+Use `vagrant` to start a remote sshd server:
+
+```
+$ vagrant up
+```
+
+Run:
+
+
+```
 $ embulk run -Ilib example/sample.yml
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "centos6.5.3"
+  config.vm.box_url = 'https://github.com/2creatives/vagrant-centos/releases/download/v6.5.3/centos65-x86_64-20140116.box'
+
+  # name
+  config.vm.define "vagrant-centos"
+  config.ssh.forward_agent = true
+  config.vm.network "forwarded_port", guest: 22, host: 2210
+end

--- a/example/sample.yml.liquid
+++ b/example/sample.yml.liquid
@@ -16,11 +16,11 @@ in:
 out:
   type: sftp
   host: 127.0.0.1
-  port: 22
-  user: your_name
-  password: your_password
-  secret_key_file: your_secret_key_file
-  secret_key_passphrase: your_secret_key_passphrase
+  port: 2210
+  user: vagrant
+  # password:
+  secret_key_file: {{ env.PWD }}/.vagrant/machines/vagrant-centos/virtualbox/private_key
+  # secret_key_passphrase:
   user_directory_is_root: true
   path_prefix: /tmp/embulk_output_sftp/data
   file_ext: .tsv
@@ -37,3 +37,4 @@ out:
       escape: "\\"
       null_string: ""
       default_timezone: 'UTC'
+

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -172,7 +172,7 @@ public class SftpFileOutput
             try {
                 withConnectionRetry(retriable);
             }
-            } catch (Exception e) {
+            catch (Exception e) {
                 throw (IOException)e;
             }
         }
@@ -220,7 +220,8 @@ public class SftpFileOutput
             currentFile.getContent().close();
             currentFile.close();
         }
-        catch (IOException e) {
+        catch (FileSystemException e) {
+            IOException e) {
             logger.error(e.getMessage());
             Throwables.propagate(e);
         }
@@ -263,7 +264,8 @@ public class SftpFileOutput
         while (true) {
             try {
                 return op.execute();
-            } catch(final Exception e) {
+            }
+            catch(final Exception e) {
                 if (++count > maxConnectionRetry) {
                     throw e;
                 }
@@ -302,7 +304,8 @@ public class SftpFileOutput
         };
         try {
             return withConnectionRetry(retriable);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw (FileSystemException)e;
         }
     }
@@ -318,7 +321,8 @@ public class SftpFileOutput
         };
         try {
             return withConnectionRetry(retriable);
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             throw (FileSystemException)e;
         }
     }

--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -217,19 +217,21 @@ public class SftpFileOutput
 
         try {
             currentFileOutputStream.close();
-            currentFile.getContent().close();
+        }
+        catch (IOException e) {
+            logger.info(e.getMessage());
+        }
+
+        try {
             currentFile.close();
         }
         catch (FileSystemException e) {
-            IOException e) {
-            logger.error(e.getMessage());
-            Throwables.propagate(e);
+            logger.warn(e.getMessage());
         }
-        finally {
-            fileIndex++;
-            currentFile = null;
-            currentFileOutputStream = null;
-        }
+
+        fileIndex++;
+        currentFile = null;
+        currentFileOutputStream = null;
     }
 
     private URI getSftpFileUri(String remoteFilePath)


### PR DESCRIPTION
This possibly fixes several connection issues such as below:

## (1) Could not write to

```
2016-03-14T09:10:37 [WARN]         org.apache.commons.vfs2.FileSystemException: Could not write to \"sftp://xxxx/xxxxx\".\n\tat
2016-03-14T09:10:37 [WARN]         com.google.common.base.Throwables.propagate(Throwables.java:160)\n\tat 
2016-03-14T09:10:37 [WARN]         org.embulk.output.sftp.SftpFileOutput.nextFile(SftpFileOutput.java:122)\n\tat
2016-03-14T09:10:37 [WARN]         org.embulk.spi.util.FileOutputOutputStream.nextFile(FileOutputOutputStream.java:34)\n\tat
```

## (2) Possible write failure

I did not meet with this on the production, but it possibly can happen. Fixed to retry write to output stream. 

NOTE: Retry writing may occur duplication, users should always check number of rows coming from input, and number of rows written into output. I advise that users do such check always even if they do not turn on retry feature. 

## (3) Could not close the output stream for file

```
2016-03-14T12:10:43 [WARN] Caused by: java.lang.RuntimeException: org.apache.commons.vfs2.FileSystemException: Could not close the output stream for file "xxxx.zip".
2016-03-14T12:10:43 [WARN] \tat com.google.common.base.Throwables.propagate(Throwables.java:160)
2016-03-14T12:10:43 [WARN] \tat org.embulk.output.sftp.SftpFileOutput.closeCurrentFile(SftpFileOutput.java:181)
2016-03-14T12:10:43 [WARN] \tat org.embulk.output.sftp.SftpFileOutput.close(SftpFileOutput.java:152)
```

## Extra

I also added Vagrantfile so that example can easily be ran.