### PR TITLE
[Fix bugs] Plugin throws ClassNotFoundException with EmbulkEmbed

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -55,6 +55,7 @@ public class SftpFileOutput
             System.setProperty("org.apache.commons.logging.Log", "org.apache.commons.logging.impl.NoOpLog");
         }
         StandardFileSystemManager manager = new StandardFileSystemManager();
+        manager.setClassLoader(SftpFileOutput.class.getClassLoader());
         try {
             manager.init();
         }


### PR DESCRIPTION
I found that plugin throws `java.lang.ClassNotFoundException: org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider` and I fixed it.
This error happens only at an environment that are using EmbulkEmbed.

### part of Stacktrace
```shell
2016-03-22 07:18:20.454 +0000 [INFO] (0001:transaction): Loaded plugin embulk-output-sftp (0.0.5)
2016-03-22 07:18:20.547 +0000 [INFO] (0001:transaction): Loaded plugin embulk-parser-msgpack (0.2.1)
2016-03-22 07:18:20.586 +0000 [INFO] (0001:transaction): Listing local files at directory '/path/to/input' filtering filename by prefix 'output'
2016-03-22 07:18:20.592 +0000 [INFO] (0001:transaction): Loading files [/path/to/file]
2016-03-22 07:18:20.663 +0000 [INFO] (0001:transaction): Using local thread executor with max_threads=4 / tasks=1
2016-03-22 07:18:20.723 +0000 [INFO] (0001:transaction): {done:  0 / 1, running: 0}
2016-03-22 07:18:20.795 +0000 [ERROR] (0013:task-0000): Could not load VFS configuration from "jar:file:/path/to/gems/embulk-output-sftp-0.0.5/classpath/commons-vfs2-2.1.1660580.2.jar!/org/apache/commons/vfs2/impl/providers.xml".
2016-03-22 07:18:20.796 +0000 [INFO] (0001:transaction): {done:  1 / 1, running: 0}
org.embulk.config.ConfigException: org.apache.commons.vfs2.FileSystemException: Could not load VFS configuration from "jar:file:/path/to/gems/embulk-output-sftp-0.0.5/classpath/commons-vfs2-2.1.1660580.2.jar!/org/apache/commons/vfs2/impl/providers.xml".
org.embulk.exec.PartialExecutionException: org.embulk.config.ConfigException: org.apache.commons.vfs2.FileSystemException: Could not load VFS configuration from "jar:file:/path/to/gems/embulk-output-sftp-0.0.5/classpath/commons-vfs2-2.1.1660580.2.jar!/org/apache/commons/vfs2/impl/providers.xml".
    at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:363)
    at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:572)
    at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
    at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:374)
    at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:370)
    at org.embulk.spi.Exec.doWith(Exec.java:25)
    at org.embulk.exec.BulkLoader.run(BulkLoader.java:370)
    at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
    ....
Caused by: org.embulk.config.ConfigException: org.apache.commons.vfs2.FileSystemException: Could not load VFS configuration from "jar:file:/path/to/gems/embulk-output-sftp-0.0.5/classpath/commons-vfs2-2.1.1660580.2.jar!/org/apache/commons/vfs2/impl/providers.xml".
    at org.embulk.output.sftp.SftpFileOutput.initializeStandardFileSystemManager(SftpFileOutput.java:62)
    at org.embulk.output.sftp.SftpFileOutput.<init>(SftpFileOutput.java:128)
    at org.embulk.output.sftp.SftpFileOutputPlugin.open(SftpFileOutputPlugin.java:110)
    at org.embulk.spi.FileOutputRunner.open(FileOutputRunner.java:133)
    at org.embulk.spi.util.Executors.process(Executors.java:56)
    at org.embulk.spi.util.Executors.process(Executors.java:42)
    at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:184)
    at org.embulk.exec.LocalExecutorPlugin$DirectExecutor$1.call(LocalExecutorPlugin.java:180)
    at java.util.concurrent.FutureTask.run(FutureTask.java:262)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:745)
Caused by: org.apache.commons.vfs2.FileSystemException: Could not load VFS configuration from "jar:file:/path/to/gems/embulk-output-sftp-0.0.5/classpath/commons-vfs2-2.1.1660580.2.jar!/org/apache/commons/vfs2/impl/providers.xml".
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.configure(StandardFileSystemManager.java:194)
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.init(StandardFileSystemManager.java:117)
    at org.embulk.output.sftp.SftpFileOutput.initializeStandardFileSystemManager(SftpFileOutput.java:58)
    ... 11 more
Caused by: org.apache.commons.vfs2.FileSystemException: Could not create file provider of class "org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider".
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.createInstance(StandardFileSystemManager.java:488)
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.addProvider(StandardFileSystemManager.java:370)
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.configure(StandardFileSystemManager.java:268)
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.configure(StandardFileSystemManager.java:190)
    ... 13 more
Caused by: java.lang.ClassNotFoundException: org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider
    at java.net.URLClassLoader$1.run(URLClassLoader.java:366)
    at java.net.URLClassLoader$1.run(URLClassLoader.java:355)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:354)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:425)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:358)
    at org.apache.commons.vfs2.impl.StandardFileSystemManager.createInstance(StandardFileSystemManager.java:483)
    ... 16 more
```