### PR TITLE
Fix CI failure only with Java7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile  "org.embulk:embulk-core:0.8.6"
     provided "org.embulk:embulk-core:0.8.6"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
-    compile "org.apache.commons:commons-vfs2:2.+"
+    compile "org.apache.commons:commons-vfs2:2.1.1660580.2"
     compile "com.jcraft:jsch:0.1.53"
     testCompile "junit:junit:4.+"
     testCompile "org.embulk:embulk-core:0.8.6:tests"


### PR DESCRIPTION
CI for Current code fails only with Java7.
https://travis-ci.org/sakama/embulk-output-sftp/builds/162703491
```
warning: /home/travis/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-vfs2/2.1.1744488.1/af8c7d2da3d7d04a42a59e746b6fcce17ea15988/commons-vfs2-2.1.1744488.1.jar(org/apache/commons/vfs2/FileSystemException.class): major version 52 is newer than 51, the highest major version supported by this compiler.
It is recommended that the compiler be upgraded.
```


commons-vfs2-2.1.17 seems not to support Java8.
I fixed version at build.gradle.
This is a same version that with bundled with gem file.
