### PR TITLE
Use second as timetout setting instead of milli second

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -83,7 +83,7 @@ public class SftpFileOutput
         try {
             SftpFileSystemConfigBuilder builder = SftpFileSystemConfigBuilder.getInstance();
             builder.setUserDirIsRoot(fsOptions, task.getUserDirIsRoot());
-            builder.setTimeout(fsOptions, task.getSftpConnectionTimeout());
+            builder.setTimeout(fsOptions, task.getSftpConnectionTimeout() * 1000);
             builder.setStrictHostKeyChecking(fsOptions, "no");
             if (task.getSecretKeyFilePath().isPresent()) {
                 IdentityInfo identityInfo = new IdentityInfo(

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -185,7 +185,7 @@ public class TestSftpFileOutputPlugin
         return fileNames;
     }
 
-    private void run(String configYaml, final Optional<Integer> sleep)
+    private void run(String configYaml)
     {
         ConfigSource config = getConfigFromYaml(configYaml);
         runner.transaction(config, SCHEMA, 1, new Control()
@@ -204,15 +204,9 @@ public class TestSftpFileOutputPlugin
                                  true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L), newMap(newString("k"), newString("v")),
                                  true, 2L, 3.0D, "45", Timestamp.ofEpochMilli(678L), newMap(newString("k"), newString("v")))) {
                         pageOutput.add(page);
-                        if (sleep.isPresent()) {
-                            Thread.sleep(sleep.get() * 1000);
-                        }
                     }
                     pageOutput.commit();
                     committed = true;
-                }
-                catch (InterruptedException e) {
-                    logger.debug(e.getMessage(), e);
                 }
                 finally {
                     if (!committed) {
@@ -372,7 +366,7 @@ public class TestSftpFileOutputPlugin
                 "  default_timezone: 'UTC'";
 
         // runner.transaction -> ...
-        run(configYaml, Optional.<Integer>absent());
+        run(configYaml);
 
         List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
         assertThat(fileList, hasItem(containsString(pathPrefix + "001.00.txt")));
@@ -408,7 +402,7 @@ public class TestSftpFileOutputPlugin
                 "  default_timezone: 'UTC'";
 
         // runner.transaction -> ...
-        run(configYaml, Optional.<Integer>absent());
+        run(configYaml);
 
         List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
         assertThat(fileList, hasItem(containsString(pathPrefix + "001.00.txt")));
@@ -456,7 +450,7 @@ public class TestSftpFileOutputPlugin
                     "  default_timezone: 'UTC'";
 
             // runner.transaction -> ...
-            run(configYaml, Optional.<Integer>absent());
+            run(configYaml);
 
             List<String> fileList = lsR(Lists.<String>newArrayList(), Paths.get(testFolder.getRoot().getAbsolutePath()));
             assertThat(fileList, hasItem(containsString(pathPrefix + "001.00.txt")));

--- a/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/sftp/TestSftpFileOutputPlugin.java
@@ -4,7 +4,6 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import org.apache.commons.vfs2.FileSystemException;
 import org.apache.sshd.common.NamedFactory;
 import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
 import org.apache.sshd.server.Command;
@@ -30,7 +29,6 @@ import org.embulk.spi.PageTestUtils;
 import org.embulk.spi.Schema;
 import org.embulk.spi.TransactionalPageOutput;
 import org.embulk.spi.time.Timestamp;
-import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -472,42 +470,6 @@ public class TestSftpFileOutputPlugin
                 proxyServer.stop();
             }
         }
-    }
-
-    @Test
-    public void testTimeout()
-    {
-        // setting embulk config
-        final String pathPrefix = "/test/testUserPassword";
-        String configYaml = "" +
-                "type: sftp\n" +
-                "host: " + HOST + "\n" +
-                "port: " + PORT + "\n" +
-                "user: " + USERNAME + "\n" +
-                "secret_key_file: " + SECRET_KEY_FILE + "\n" +
-                "secret_key_passphrase: " + SECRET_KEY_PASSPHRASE + "\n" +
-                "path_prefix: " + testFolder.getRoot().getAbsolutePath() + pathPrefix + "\n" +
-                "timeout: 1\n" +
-                "file_ext: txt\n" +
-                "formatter:\n" +
-                "  type: csv\n" +
-                "  newline: CRLF\n" +
-                "  newline_in_field: LF\n" +
-                "  header_line: true\n" +
-                "  charset: UTF-8\n" +
-                "  quote_policy: NONE\n" +
-                "  quote: \"\\\"\"\n" +
-                "  escape: \"\\\\\"\n" +
-                "  null_string: \"\"\n" +
-                "  default_timezone: 'UTC'";
-
-        // exception
-        exception.expect(RuntimeException.class);
-        exception.expectCause(CoreMatchers.<Throwable>instanceOf(FileSystemException.class));
-        exception.expectMessage("Could not connect to SFTP server");
-
-        // runner.transaction -> ...
-        run(configYaml, Optional.of(60)); // sleep 1 minute while processing
     }
 
     @Test


### PR DESCRIPTION
Current code seems to intend to use 600 **sec** as default timeout value.
But actual behavior is 600 **msec**.

Second parameter of SftpFileSystemConfigBuilder.setTimeout() allows msec, it's not a sec.

> SftpFileSystemConfigBuilder.setTimeout(FileSystemOptions opts, Integer timeout)

> * Parameters:
>   * opts - The FileSystem options.
>   * timeout - The timeout in milliseconds.

https://commons.apache.org/proper/commons-vfs/apidocs/org/apache/commons/vfs2/provider/sftp/SftpFileSystemConfigBuilder.html#setTimeout

Additionally, I removed 1 test case.
Although I tried some method, timeout never happens during executing unit test.