### PR TITLE
Hide password in the log

### DIFF
--- a/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
+++ b/src/main/java/org/embulk/output/sftp/SftpFileOutput.java
@@ -296,10 +296,10 @@ public class SftpFileOutput
             {
                 FileObject file = manager.resolveFile(sftpUri.toString(), fsOptions);
                 if (file.getParent().exists()) {
-                    logger.info("parent directory {} exists there", file.getParent());
+                    logger.info("parent directory {} exists there", file.getParent().getPublicURIString());
                 }
                 else {
-                    logger.info("trying to create parent directory {}", file.getParent());
+                    logger.info("trying to create parent directory {}", file.getParent().getPublicURIString());
                     file.getParent().createFolder();
                 }
                 return file;


### PR DESCRIPTION
Current implementation is showing password in the log.
```
parent directory sftp://sftp-user:password@example.com/home/sftp-user exists there
Could not create folder "sftp://sftp-user:password@example.com/home/sftp-user"
```
I want to hide for the security reason and changed logging logic to hide them.

```
parent directory sftp://ec2-user:***@example.com/home/ec2-user exists there
Could not create folder "sftp://sftp-user:***@example.com/home/ec2-user2"
```

`FileObject.getPublicURIString()` is already used at [other part](https://github.com/civitaspo/embulk-output-sftp/blob/master/src/main/java/org/embulk/output/sftp/SftpFileOutput.java#L149).
